### PR TITLE
Adding reviewing guidelines for ASPLOS'22 AE

### DIFF
--- a/wfe/artifact-evaluation/reviewing-asplos22.html
+++ b/wfe/artifact-evaluation/reviewing-asplos22.html
@@ -94,14 +94,14 @@ demonstrate the analysis.</i>
   </ul> 
   
   <p>
-  Where a question is not applicable to a particular artifact, it should be disregard
+  Where a question is not applicable to a particular artifact, it should be disregarded
   and the artifact evaluated as appropriate. 
   Once reviews are submitted, they will be made available to the other reviewers
   in order to have a discussion towards a decision. 
   Reviews can be revised based on the discussions or feedback from the authors. 
   
   <h4>Badge recommendation</h4>
-  The reviews should include a specific recommendation for which badge(s) to award:
+  The reviews should further include a specific recommendation for which badge(s) to award:
 
   
   <table border="0" cellpadding="5" cellspacing="0">


### PR DESCRIPTION
Specific reviewing guidelines for the ASPLOS'22 AE, including a kick-the-tires phase and specific list of questions to address in reviews.

Once this is merged, this page needs to be linked to on asplos22.html instead of the 'reviewing.html'.